### PR TITLE
Dynamically allocate sensor file names

### DIFF
--- a/control.h
+++ b/control.h
@@ -21,5 +21,6 @@ void find_applesmc();	// called once at startup, before anything else!
 void scan_sensors();
 void adjust();
 void logger();
+void deallocate_sensors();
 
 #endif /* CONTROL_H_ */

--- a/macfanctl.c
+++ b/macfanctl.c
@@ -188,6 +188,8 @@ int main(int argc, char *argv[])
 		unlink(PID_FILE);
 	}
 
+	deallocate_sensors();
+
 	printf("Exiting.\n");
 
 	return 0;


### PR DESCRIPTION
Saves 100 KB of memory on my MacBook with 25 sensors.  Also deallocate
sensors on termination.  Finally use PATH_MAX where appropriate.
