### PR TITLE
Increase number of exclude-able sensors

### DIFF
--- a/config.c
+++ b/config.c
@@ -154,7 +154,7 @@ void read_exclude_list()
 
 	while(1)
 	{
-		char buf[256];
+		char buf[1024];
 		char *s = fgets(buf, sizeof(buf), fp);
 
 		if(s == NULL)

--- a/config.h
+++ b/config.h
@@ -33,7 +33,7 @@ extern int log_level;
 
 void read_cfg(char* name);
 
-#define MAX_EXCLUDE		20
+#define MAX_EXCLUDE		200
 extern int exclude[MAX_EXCLUDE];	// array of sensors to exclude
 
 #define max(a,b)	(a > b ? a : b)


### PR DESCRIPTION
Hello, Mikael! First of all, let me me tell you that macfanctld has been very useful on my system. Before it, my CPU was getting almost hot enough to boil water. Thank you very much for your hard work!

I'm running Ubuntu 12.10 with a MacbookPro10,1 (released June 2012). My system detects a large range of sensors - 44 in fact. I would like to ignore many of these sensors (many stay cool even when my CPU gets quite toasty and artificially pull the average down, others are either 0°C or 129°C but nothing in between?). It looks like in config.h, the maximum number of exclude-able is 20. Since I have many more sensors than this, I think it would be useful to significantly increase this limit. In this pull request in the exlcudefix branch, please find a simple patch that increases that limit from 20 to 200 and also increases the size of a read buffer in config.c. It seems to work great on my system. Before this patch, extra sensors beyond the 20 would be ignored.

Thanks! Please let me know if you have any questions/comments.
